### PR TITLE
Link to main gleam project in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ This is a Vim plugin that provides [Gleam][gleam] support to Vim/Neovim.
    `~/.config/nvim/init.vim` (for Neovim).
 2. Run `:PluginInstall`.
 
-[gleam]: https://github.com/lpil/gleam.vim
+[gleam]: https://github.com/lpil/gleam


### PR DESCRIPTION
The gleam link in `README.md` linked to the gleam.vim repo (which is odd!), I think it was intended to link to the main gleam repo.