### PR TITLE
Add compiler configuration

### DIFF
--- a/compiler/gleam.vim
+++ b/compiler/gleam.vim
@@ -1,0 +1,28 @@
+if exists('current_compiler')
+    finish
+endif
+
+let current_compiler = "gleam"
+
+CompilerSet makeprg=gleam\ $*
+
+" Written with the help of: https://flukus.github.io/vim-errorformat-demystified.html
+"
+let &efm='%Eerror: %m,'                   " use 'error:' to indicate the start of a new error
+let &efm.='%C %#┌── %f:%l:%c ───,'        " pull out the file, line & column
+let &efm.='%C,'                           " allow empty lines within an error
+let &efm.='%C%.%#│%.%#,'                  " ignore any line with a vertial formatting pipe in it
+let &efm.='%Z%m'                          " assume any other line contributes to the error message
+
+
+" Example error message
+"
+" error: Syntax error
+"
+"    ┌── /home/michael/root/projects/gleam-phoenix-mix/src/page_controller.gleam:7:27 ───
+"    │
+"  7 │ pub fn index(my_conn: connConn) -> conn.Conn {
+"    │                           ^^^^ Unexpected token
+"    │
+"
+" Expected one of ")", ",", ".", "=", "external", "fn", "import", "pub", "type", "{"

--- a/compiler/gleam.vim
+++ b/compiler/gleam.vim
@@ -1,18 +1,36 @@
+" Check we've not run already
 if exists('current_compiler')
     finish
 endif
 
 let current_compiler = "gleam"
 
+" Defined CompilerSet command if it doesn't exist.
+" Needed for older vim versions.
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+" Tell vim to run 'gleam' when the user runs :make. So ':make build .' becomes
+" 'gleam build .'
 CompilerSet makeprg=gleam\ $*
 
+
+" With the compiler set, we set the errorformat which is a set of rules that
+" vim uses to parse the output of the current compiler program in order to
+" extract file, line, column & error message information so that it can
+" populate the quickfix list and the user can jump between the errors.
+"
+" This errorformat 'parser' will have to change if the output of the compiler
+" changes.
+"
 " Written with the help of: https://flukus.github.io/vim-errorformat-demystified.html
 "
-let &efm='%Eerror: %m,'                   " use 'error:' to indicate the start of a new error
-let &efm.='%C %#┌── %f:%l:%c ───,'        " pull out the file, line & column
-let &efm.='%C,'                           " allow empty lines within an error
-let &efm.='%C%.%#│%.%#,'                  " ignore any line with a vertial formatting pipe in it
-let &efm.='%Z%m'                          " assume any other line contributes to the error message
+CompilerSet errorformat=%Eerror:\ %m                " use 'error:' to indicate the start of a new error
+CompilerSet errorformat+=%C\ %#┌──\ %f:%l:%c\ ───   " pull out the file, line & column
+CompilerSet errorformat+=%C                         " allow empty lines within an error
+CompilerSet errorformat+=%C%.%#│%.%#                " ignore any line with a vertial formatting pipe in it
+CompilerSet errorformat+=%Z%m                       " assume any other line contributes to the error message
 
 
 " Example error message


### PR DESCRIPTION
With an error-format specification which attempts to extract the appropriate information out of a standard gleam error message.

This the standard way to populate the quickfix list to make it easer to navigate between them with standard shortcuts.
    
Initially based on the rust vim compiler file:
    
      https://github.com/rust-lang/rust.vim/blob/master/compiler/rustc.vim
    
Though I'm not sure how much we need to bring across.
