### PR TITLE
Add 'compiler' command to ftplugin

### DIFF
--- a/ftplugin/gleam.vim
+++ b/ftplugin/gleam.vim
@@ -1,5 +1,10 @@
-augroup gleam.vim
-autocmd!
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+compiler gleam
 
 setlocal commentstring=//%s
 setlocal formatoptions-=t formatoptions+=croqnl
@@ -17,3 +22,7 @@ setlocal tabstop=2 shiftwidth=2 softtabstop=2 expandtab
 setlocal textwidth=79
 
 setlocal suffixesadd=.gleam
+
+augroup gleam.vim
+autocmd!
+augroup END


### PR DESCRIPTION
I can separate out these changes if you'd like some and not others. They are a bit opinionated but only from copying from the rust.vim project. The 'compiler' line is definitely necessary though. I don't know what it is about my regular set up that didn't require this but when doing one from scratch it is definitely necessary.

---

When trying to get a set up working from fresh, I couldn't get the
compiler ':make' functionality to work. It seems it isn't picked up
automatically and needs a line like this.

We also move the augroup to the bottom and give an END.

And add a check at the start to make sure we're only sourcing this file
once and only if we've not loaded any other ftplugins.

These changes are entirely based on the ftplugin/rust.vim:

   https://github.com/rust-lang/rust.vim/blob/master/ftplugin/rust.vim

There is a chance that we're copying bad practices from them but it
seems reasonable. I don't know anything about augroups but it seems like
they should have an end and moving it to the bottom makes it clearer
what is and isn't intended to be included in the group.