### PR TITLE
Update to match last version of gleam

### DIFF
--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -8,7 +8,9 @@ let b:current_syntax = "gleam"
 
 " Keywords
 syntax keyword gleamKeyword
-  \ import pub panic use type let as if else todo const case assert try opaque
+  \ import pub panic use
+  \ type let as if else todo const
+  \ case assert try opaque
 highlight link gleamKeyword Keyword
 
 " Function definition

--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -23,19 +23,19 @@ highlight link gleamFunctionDef Function
 
 " Number
 "" Int
-syntax match gleamInt '\<\d[0-9_]*\>'
+syntax match gleamInt '\<\(0*[1-9][0-9_]*|0\)\>'
 highlight link gleamInt Number
 
 "" Binary
-syntax match gleamBinary '\<0[bB][01]+\>'
+syntax match gleamBinary '\<0[bB]\(0*1[01_]*\|0\)\>'
 highlight link gleamBinary Number
 
 "" Octet
-syntax match gleamOctet '\<0[oO][0-7]+\>'
+syntax match gleamOctet '\<0[oO]\(0*[1-7][0-7_]*\|0\)\>'
 highlight link gleamOctet Number
 
 "" Hexadecimal
-syntax match gleamHexa '\<0[xX]\x+\>'
+syntax match gleamHexa '\<0[xX]\(0*[1-9a-zA-Z][0-9a-zA-Z_]*\|0\)\>'
 highlight link gleamHexa Number
 
 "" Float

--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -85,5 +85,5 @@ highlight link gleamString String
 highlight link gleamStringModifier Special
 
 " Attribute
-syntax match gleamAttribute "@\(external\|deprecated\|target\)"
+syntax match gleamAttribute "@[a-z][a-z_]*"
 highlight link gleamAttribute PreProc

--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -8,32 +8,65 @@ let b:current_syntax = "gleam"
 
 " Keywords
 syntax keyword gleamKeyword
-  \ module import pub panic use
-  \ type let as if else todo const
-  \ case assert tuple try opaque
+  \ import pub panic use type let as if else todo const case assert try opaque
 highlight link gleamKeyword Keyword
 
 " Function definition
 syntax keyword gleamDef fn nextgroup=gleamFunctionDef skipwhite skipempty
 highlight link gleamDef Keyword
 
-syntax match gleamFunctionDef "[a-z_-][0-9a-z_-]*" contained skipwhite skipnl
+syntax match gleamFunctionDef "[a-z][a-z0-9_]*\ze\s*(" skipwhite skipnl
+highlight link gleamFunctionDef Function
 highlight link gleamFunctionDef Function
 
-" Int
-syntax match gleamInt '\<\(0x[a-fA-F0-9_]\+\|[0-9][0-9_]*\)\>'
+" Number
+"" Int
+syntax match gleamInt '\<\d[0-9_]*\>'
 highlight link gleamInt Number
 
-" Float
-syntax match gleamFloat '\<[0-9][0-9_]*\.[0-9_]*\>'
+"" Binary
+syntax match gleamBinary '\<0[bB][01]+\>'
+highlight link gleamBinary Number
+
+"" Octet
+syntax match gleamOctet '\<0[oO][0-7]+\>'
+highlight link gleamOctet Number
+
+"" Hexadecimal
+syntax match gleamHexa '\<0[xX]\x+\>'
+highlight link gleamHexa Number
+
+"" Float
+syntax match gleamFloat '\d\(_\=\d\)*\.\(e-\=\d\)\=[0-9_]*'
 highlight link gleamFloat Float
 
 " Operators
-syntax match gleamOperator "\([-!#$%`&\*\+./<=>@\\^|~:]\|\<\>\)"
+"" Basic
+syntax match gleamOperator "[-+/*]\.\=\|[%=]"
 highlight link gleamOperator Operator
 
+"" Arrows + Pipeline
+syntax match gleamOperator "<-\|[-|]>"
+highlight link gleamOperator Operator
+
+"" Bool
+syntax match gleamOperator "&&\|||"
+highlight link gleamOperator Operator
+
+"" Comparison
+syntax match gleamOperator "[<>]=\=\.\=\|[=!]="
+highlight link gleamOperator Operator
+
+"" Misc
+syntax match gleamOperator "\.\.\|<>\||"
+highlight link gleamOperator Operator
+
+" Values
+syntax keyword gleamValues True False Nil
+highlight def link gleamValues Boolean
+
 " Type
-syntax match gleamType "\([a-z]\)\@<![A-Z]\w*"
+syntax match gleamType "\<[A-Z][a-zA-Z0-9]*\>"
 highlight link gleamType Identifier
 
 " Comments
@@ -50,5 +83,5 @@ highlight link gleamString String
 highlight link gleamStringModifier Special
 
 " Attribute
-syntax match gleamAttribute "#[a-z][a-z_]*"
+syntax match gleamAttribute "@\(external\|deprecated\|target\)"
 highlight link gleamAttribute PreProc

--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -39,7 +39,7 @@ syntax match gleamHexa '\<0[xX]\(0*[1-9a-zA-Z][0-9a-zA-Z_]*\|0\)\>'
 highlight link gleamHexa Number
 
 "" Float
-syntax match gleamFloat '\d\(_\=\d\)*\.\(\d\(_\=\d\)*\)\=\(e-\=\d\)\=[0-9_]*'
+syntax match gleamFloat '\(0*[1-9][0-9_]*\|0\)\.\(0*[1-9][0-9_]*\|0\)\(e-\=0*[1-9][0-9_]*\)\='
 highlight link gleamFloat Float
 
 " Operators

--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -37,7 +37,7 @@ syntax match gleamHexa '\<0[xX]\x+\>'
 highlight link gleamHexa Number
 
 "" Float
-syntax match gleamFloat '\d\(_\=\d\)*\.\(e-\=\d\)\=[0-9_]*'
+syntax match gleamFloat '\d\(_\=\d\)*\.\(\d\(_\=\d\)*\)\=\(e-\=\d\)\=[0-9_]*'
 highlight link gleamFloat Float
 
 " Operators


### PR DESCRIPTION
I just took a look at gleam to use in a project. While I was writing a plugin for my editor, kakoune, I saw discrepencies between editor's plugins and gleam current grammar.
I thought it would be a good first contribution :)

Fixes :
- Outdated regexes
- Missing Nil highlighting
- Missing some keywords